### PR TITLE
Fix "Forbenius" typos in Lecture 2

### DIFF
--- a/Lecture02/main.tex
+++ b/Lecture02/main.tex
@@ -106,9 +106,9 @@ $$ = C \underbrace{x^{-2}}_{\text{Capture the singularity}} \underbrace{\left[ 1
 
 $$ y(x) = \underbrace{x^r}_{\text{Capture singularity}} \sum_{n = 0}^{\infty} a_n x^n$$
 
-This brings us to the \textbf{Forbenius Series}. 
+This brings us to the \textbf{Frobenius Series}. 
 
-\section{Forbenius Series}
+\section{Frobenius Series}
 
 Let's define ordinary \& singular points:
 
@@ -128,7 +128,7 @@ Analytic means that is is expressible as a power series around $x_0$. It means t
 
 \begin{itemize}
     \item A power series solution is possible for all ordinary points (similar to the first example we saw), but not all singular points. 
-    \item For singular points, we introduce the Forbenius Series. However, this only works for some singular points. 
+    \item For singular points, we introduce the Frobenius Series. However, this only works for some singular points. 
     \item Singular points results in the change of the nature of the ODE. Ordinary points exists in the domain of $p(x)$ and $q(x)$. 
     \item The radius of convergence of the power series is at least as large as the distance from the $x_0$ to the nearest singular point.
     \begin{itemize}
@@ -152,8 +152,8 @@ There are no singular points. Hence the radius of convergence is infinity.
 Singular points are divided into two classes:
 
 \begin{itemize}
-    \item Regular singular points, that we use the Forbenius series solution for
-    \item Irregular singular points (Beyond this course). For these, we \textbf{cannot} use Forbenius series. 
+    \item Regular singular points, that we use the Frobenius series solution for
+    \item Irregular singular points (Beyond this course). For these, we \textbf{cannot} use Frobenius series. 
 \end{itemize}
 
 \end{document}


### PR DESCRIPTION
Replaced Parisa's misspelling of Frobenius in Lecture 2 with the correct spelling.